### PR TITLE
New Feature: Position of Doubling

### DIFF
--- a/Pipfile
+++ b/Pipfile
@@ -5,18 +5,17 @@ name = "pypi"
 
 [packages]
 pyperf = "*"
+hypothesis = "*"
 hypothesis-jsonschema = "*"
 pandas = "*"
+PrettyTable = "*"
 
 [dev-packages]
-PrettyTable = "*"
 pylint = "*"
 neovim = "*"
 black = "*"
 pytest = "*"
 pytest-benchmark = "*"
-hypothesis = "*"
-pyperf = "*"
 codecov = "*"
 "flake8" = "*"
 pytest-cov = "*"

--- a/Pipfile
+++ b/Pipfile
@@ -17,8 +17,10 @@ black = "*"
 pytest = "*"
 pytest-benchmark = "*"
 codecov = "*"
-"flake8" = "*"
+flake8 = "*"
 pytest-cov = "*"
+deap = "*"
+python-constraint = "*"
 
 [pipenv]
 allow_prereleases = true

--- a/README.md
+++ b/README.md
@@ -90,8 +90,9 @@ optional arguments:
   --sorted SORTED       Enable input data to be sorted: (0|1) (default: 0)
   --level LEVEL         The level of nested data structure to apply doubling
                         experiment (default: 1)
-  --position POSITION   The position of nested data structure to apply doubling
-                        experiment (default: [0])
+  --position POSITION_FOR_FIRST_LEVEL POSITION_FOR_SECOND_LEVEL ETC
+                        The position of input data to double in the multivariable
+                        doubling experiment (default: "0")
 
 Sample usage: pipenv run python tada_a_bigoh.py --directory
 /Users/myname/projectdirectory --module modulename.file --function

--- a/README.md
+++ b/README.md
@@ -90,6 +90,8 @@ optional arguments:
   --sorted SORTED       Enable input data to be sorted: (0|1) (default: 0)
   --level LEVEL         The level of nested data structure to apply doubling
                         experiment (default: 1)
+  --position POSITION   The position of nested data structure to apply doubling
+                        experiment (default: [0])
 
 Sample usage: pipenv run python tada_a_bigoh.py --directory
 /Users/myname/projectdirectory --module modulename.file --function

--- a/perf_benchmark.py
+++ b/perf_benchmark.py
@@ -44,8 +44,9 @@ if __name__ == "__main__":
         # read path from arguments
         path = configuration.get_schema_path(tada_configuration_dict)
     level = configuration.get_level(tada_configuration_dict)
+    position = configuration.get_position(tada_configuration_dict)
     # generate data
-    data = generate.generate_data(func_type, chosen_size, level, path)
+    data = generate.generate_data(func_type, chosen_size, level, position, path)
     # run benchmark
     if configuration.get_sortinput(tada_configuration_dict) == 1:
         for t in data:

--- a/tada/util/arguments.py
+++ b/tada/util/arguments.py
@@ -115,7 +115,8 @@ def parse(args):
     parser.add_argument(
         "--position",
         required=False,
-        type=list,
+        nargs="+",
+        type=int,
         default=constants.POSITION,
         help="The position of nested data structure to apply doubling experiment",
     )

--- a/tada/util/arguments.py
+++ b/tada/util/arguments.py
@@ -118,7 +118,8 @@ def parse(args):
         nargs="+",
         type=int,
         default=constants.POSITION,
-        help="The position of nested data structure to apply doubling experiment",
+        help="""The position of input data to double in the multivariable
+        doubling experiment""",
     )
     # parse the arguments and return the finished result
     arguments_finished = parser.parse_args(args)

--- a/tada/util/arguments.py
+++ b/tada/util/arguments.py
@@ -112,6 +112,13 @@ def parse(args):
         default=constants.LEVEL,
         help="The level of nested data structure to apply doubling experiment",
     )
+    parser.add_argument(
+        "--position",
+        required=False,
+        type=list,
+        default=constants.POSITION,
+        help="The position of nested data structure to apply doubling experiment",
+    )
     # parse the arguments and return the finished result
     arguments_finished = parser.parse_args(args)
     return arguments_finished

--- a/tada/util/configuration.py
+++ b/tada/util/configuration.py
@@ -33,6 +33,11 @@ def get_level(current_dictionary):
     return current_dictionary[LEVEL]
 
 
+def get_position(current_dictionary):
+    """Return the position argument from the provided dictionary"""
+    return current_dictionary[POSITION]
+
+
 def get_sortinput(current_dictionary):
     """Return the sortinput argument from the provided dictionary"""
     return current_dictionary[SORTED]

--- a/tada/util/configuration.py
+++ b/tada/util/configuration.py
@@ -36,9 +36,7 @@ def get_level(current_dictionary):
 
 def get_position(current_dictionary):
     """Return the position argument from the provided dictionary"""
-    position_str = current_dictionary[POSITION][1:-1]
-    results = list(map(int, position_str))
-    return results
+    return current_dictionary[POSITION]
 
 
 def get_sortinput(current_dictionary):

--- a/tada/util/configuration.py
+++ b/tada/util/configuration.py
@@ -13,6 +13,7 @@ TYPES = "types"
 SCHEMA = "schema"
 LEVEL = "level"
 SORTED = "sorted"
+POSITION = "position"
 
 
 def save(configuration_filename, tada_configuration):

--- a/tada/util/configuration.py
+++ b/tada/util/configuration.py
@@ -36,7 +36,9 @@ def get_level(current_dictionary):
 
 def get_position(current_dictionary):
     """Return the position argument from the provided dictionary"""
-    return current_dictionary[POSITION]
+    position_str = current_dictionary[POSITION][1:-1]
+    results = list(map(int, position_str))
+    return results
 
 
 def get_sortinput(current_dictionary):

--- a/tada/util/constants.py
+++ b/tada/util/constants.py
@@ -14,6 +14,7 @@ BACKFILL = 0
 MAX_SIZE = 1500
 SORT = 0
 LEVEL = 1
+POSITION = [0]
 
 # Names
 TADA = "tada"

--- a/tada/util/constants.py
+++ b/tada/util/constants.py
@@ -14,7 +14,7 @@ BACKFILL = 0
 MAX_SIZE = 1500
 SORT = 0
 LEVEL = 1
-POSITION = [0]
+POSITION = "0"
 
 # Names
 TADA = "tada"

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -22,6 +22,7 @@ TYPES = ["int", "int_list", "char", "char_list", "boolean", "string", "float"]
 global_data = ()
 
 
+# pylint: disable=W0102
 def store_data_to_global(path, chosen_size, level=1, position=[0]):
     """Generate data through global variable"""
 
@@ -45,10 +46,12 @@ def store_data_to_file(a):
         f.write(str(a))
 
 
+# pylint: disable=W0102
 def generate_experiment_strategy(path, size, level=1, position=[0]):
     """generate strategies from a schema path and current input size"""
     json_schema = read.read_schema(path)
 
+    # pylint: disable=W0102
     def detect_level_and_position(json_schema, size, level=1, position=[0], index_position=0):
         """A dummy function to store the data to file for experiment"""
         schema = json_schema[position[index_position]]
@@ -82,6 +85,7 @@ def double_experiment_size(schema, size):
         schema["minimum"] = int(size)
 
 
+# pylint: disable=W0102
 def generate_func(function, path, size, level=1, position=[0]):
     """generate a function with strategy from schema path and current input size"""
     strategy = generate_experiment_strategy(path, size, level, position)
@@ -115,6 +119,7 @@ def generate_func_from_single_st(function, strategy):
     return function
 
 
+# pylint: disable=W0102
 def generate_data(chosen_types, chosen_size, level=1, position=[0], path=None):
     """Generate a list of data values"""
     generated_values = ()

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -50,18 +50,23 @@ def generate_experiment_strategy(path, size, level=1, position=[0]):  # pylint: 
     """generate strategies from a schema path and current input size"""
     json_schema = read.read_schema(path)
 
-    # pylint: disable=W0102
-    def detect_level_and_position(json_schema, size, level=1, position=[0], index_position=0):
+    # pylint: disable=W0102, R1705
+    def detect_level_and_position(schema, level=1, position=[0], index_position=0):
         """A dummy function to store the data to file for experiment"""
-        schema = json_schema[position[index_position]]
-        level -= 1
-        index_position += 1
         if level == 0:
-            double_experiment_size(schema, size)
-        while level > 0:
-            detect_level_and_position(schema, size, level, position, index_position)
+            print(schema)
+            return schema
+        else:
+            if isinstance(schema, list):
+                subschema = schema[position[index_position]]
+            elif isinstance(schema, dict):
+                subschema = schema["items"][position[index_position]]
+            return detect_level_and_position(
+                subschema, level - 1, position, index_position + 1
+            )
 
-    detect_level_and_position(json_schema, size, level, position)
+    js = detect_level_and_position(json_schema, level, position)
+    double_experiment_size(js, size)
     strategy = []
     for j in json_schema:
         strategy.append(from_schema(j))

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -84,7 +84,7 @@ def double_experiment_size(schema, size):
 
 def generate_func(function, path, size, level=1, position=[0]):
     """generate a function with strategy from schema path and current input size"""
-    strategy = generate_experiment_strategy(json_schema, size, level, position)
+    strategy = generate_experiment_strategy(path, size, level, position)
     function = given(*strategy)(function)
     # configure hypothesis
     function = settings(

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -77,8 +77,10 @@ def double_experiment_size(schema, size):
     elif schema.get("type") == "object":
         schema["maxProperties"] = int(size)
         schema["minProperties"] = int(size)
+    elif schema.get("type") == "string":
+        schema["maxLength"] = int(size)
+        schema["minLength"] = int(size)
     else:
-        print("didn't recognize array or object")
         schema["maximum"] = int(size)
         schema["minimum"] = int(size)
 

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -45,24 +45,21 @@ def store_data_to_file(a):
         f.write(str(a))
 
 
-def generate_experiment_strategy(path, size, level=1):
+def generate_experiment_strategy(path, size, level=1, position=[0]):
     """generate strategies from a schema path and current input size"""
     json_schema = read.read_schema(path)
-    # change the size as the experiment doubles
-    if level == 1:
-        for schema in json_schema:
+
+    def detect_level_and_position(json_schema, size, level=1, position=[0], index_position=0):
+        """A dummy function to store the data to file for experiment"""
+        schema = json_schema[position[index_position]]
+        level -= 1
+        index_position += 1
+        if level == 0:
             double_experiment_size(schema, size)
-    elif level == 2:
-        for schema in json_schema:
-            for schema2 in schema:
-                double_experiment_size(schema2, size)
-    elif level == 3:
-        for schema in json_schema:
-            for schema2 in schema:
-                for schema3 in schema2:
-                    double_experiment_size(schema3, size)
-    else:
-        print("More levels need to be handled")
+        while level > 0:
+            detect_level_and_position(schema, size, level, position, index_position)
+
+    detect_level_and_position(json_schema, size, level, position)
     strategy = []
     for j in json_schema:
         strategy.append(from_schema(j))
@@ -87,7 +84,7 @@ def double_experiment_size(schema, size):
 
 def generate_func(function, path, size, level=1):
     """generate a function with strategy from schema path and current input size"""
-    strategy = generate_experiment_strategy(path, size, level)
+    strategy = generate_experiment_strategy(json_schema, size, level)
     function = given(*strategy)(function)
     # configure hypothesis
     function = settings(

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -22,7 +22,7 @@ TYPES = ["int", "int_list", "char", "char_list", "boolean", "string", "float"]
 global_data = ()
 
 
-def store_data_to_global(path, chosen_size, level=1):
+def store_data_to_global(path, chosen_size, level=1, position=[0]):
     """Generate data through global variable"""
 
     def store_global(a):
@@ -31,7 +31,7 @@ def store_data_to_global(path, chosen_size, level=1):
         global global_data
         global_data = global_data + (a,)
 
-    strategies = generate_experiment_strategy(path, chosen_size, level)
+    strategies = generate_experiment_strategy(path, chosen_size, level, position)
     # store data based on the amount of parameters
     for st in strategies:
         gen = generate_func_from_single_st(store_global, st)
@@ -82,9 +82,9 @@ def double_experiment_size(schema, size):
         schema["minimum"] = int(size)
 
 
-def generate_func(function, path, size, level=1):
+def generate_func(function, path, size, level=1, position=[0]):
     """generate a function with strategy from schema path and current input size"""
-    strategy = generate_experiment_strategy(json_schema, size, level)
+    strategy = generate_experiment_strategy(json_schema, size, level, position)
     function = given(*strategy)(function)
     # configure hypothesis
     function = settings(
@@ -115,7 +115,7 @@ def generate_func_from_single_st(function, strategy):
     return function
 
 
-def generate_data(chosen_types, chosen_size, level=1, path=None):
+def generate_data(chosen_types, chosen_size, level=1, position=[0], path=None):
     """Generate a list of data values"""
     generated_values = ()
     if chosen_types[0] in TYPES:
@@ -125,7 +125,7 @@ def generate_data(chosen_types, chosen_size, level=1, path=None):
             generated_value = generator_to_invoke(chosen_size)
             generated_values = generated_values + (generated_value,)
     elif chosen_types[0] == "hypothesis":
-        generated_values = store_data_to_global(path, chosen_size, level)
+        generated_values = store_data_to_global(path, chosen_size, level, position)
     return generated_values
 
 

--- a/tada/util/generate.py
+++ b/tada/util/generate.py
@@ -46,8 +46,7 @@ def store_data_to_file(a):
         f.write(str(a))
 
 
-# pylint: disable=W0102
-def generate_experiment_strategy(path, size, level=1, position=[0]):
+def generate_experiment_strategy(path, size, level=1, position=[0]):  # pylint: disable=W0102
     """generate strategies from a schema path and current input size"""
     json_schema = read.read_schema(path)
 

--- a/tada_a_bigoh.py
+++ b/tada_a_bigoh.py
@@ -63,7 +63,7 @@ if __name__ == "__main__":
             if "hypothesis" in tada_arguments.types[0]:
                 if current_size >= tada_arguments.maxsize:
                     constants.QUIT_BY_MAX_SIZE = 1
-                    print("Quit due to researched max size")
+                    print("Quit due to reached max size")
                     break
             display.display_start_message(current_size)
             current_output, current_error = run.run_command(

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -313,7 +313,7 @@ def test_configuration_file_correct_experiment_info(
     ],
 )
 # pylint: disable=invalid-name
-def test_configuration_file_correct_types(correct_arguments, correct_position, tmpdir):
+def test_configuration_file_correct_position(correct_arguments, correct_position, tmpdir):
     """Checks that the configuration file was saved to the directory"""
     parsed_arguments = arguments.parse(correct_arguments)
     directory_prefix = str(tmpdir) + "/"

--- a/tests/test_configuration.py
+++ b/tests/test_configuration.py
@@ -286,3 +286,42 @@ def test_configuration_file_correct_experiment_info(
         configuration.get_experiment_info(tada_configuration_dict)
         == correct_experiment_info
     )
+
+
+@pytest.mark.parametrize(
+    "correct_arguments, correct_position",
+    [
+        (
+            [
+                "--directory",
+                "D",
+                "--module",
+                "M",
+                "--function",
+                "F",
+                "--types",
+                "int",
+                "float",
+                "text",
+                "--position",
+                "1",
+                "0",
+                "1",
+            ],
+            [1, 0, 1],
+        )
+    ],
+)
+# pylint: disable=invalid-name
+def test_configuration_file_correct_types(correct_arguments, correct_position, tmpdir):
+    """Checks that the configuration file was saved to the directory"""
+    parsed_arguments = arguments.parse(correct_arguments)
+    directory_prefix = str(tmpdir) + "/"
+    configuration.save(
+        directory_prefix + constants.CONFIGURATION, vars(parsed_arguments)
+    )
+    assert len(tmpdir.listdir()) == 1
+    tada_configuration_dict = configuration.read(
+        directory_prefix + constants.CONFIGURATION
+    )
+    assert configuration.get_position(tada_configuration_dict) == correct_position

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -224,7 +224,6 @@ allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
     )
 
 
-
 def test_generate_func_from_single_st():
     """Checks that generate function from single strategy works"""
     # pylint: disable=blacklisted-name

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -237,20 +237,8 @@ def test_detect_level_and_position(tmpdir):
     strategy = generate.generate_experiment_strategy(path, size, level,
                                                      position)
     assert (
-        str(strategy)
-        == '[builds(<function _operator.add>, tuples(floats(min_value=50.0, \
-max_value=50.0, allow_infinity=False, \
-allow_nan=False).filter(lambda n: <unknown>), floats(allow_infinity=False, \
-allow_nan=False).filter(lambda n: <unknown>)).map(list), \
-lists(recursive(one_of(one_of(one_of(one_of(none(), booleans()), integers()), \
-floats(allow_infinity=False, allow_nan=False).map(lambda x: <unknown>)), \
-text()), lambda strategy: st.lists(strategy, max_size=3), max_leaves=100))), \
-builds(<function _operator.add>, tuples(floats(allow_infinity=False, \
-allow_nan=False).filter(lambda n: <unknown>), floats(allow_infinity=False, \
-allow_nan=False).filter(lambda n: <unknown>)).map(list), \
-lists(recursive(one_of(one_of(one_of(one_of(none(), booleans()), integers()), \
-floats(allow_infinity=False, allow_nan=False).map(lambda x: <unknown>)), \
-text()), lambda strategy: st.lists(strategy, max_size=3), max_leaves=100)))]'
+        str(strategy[1])
+        == 'builds(<function _operator.add>, tuples(floats(allow_infinity=False, allow_nan=False).filter(lambda n: <unknown>), floats(allow_infinity=False, allow_nan=False).filter(lambda n: <unknown>)).map(list), lists(recursive(one_of(one_of(one_of(one_of(none(), booleans()), integers()), floats(allow_infinity=False, allow_nan=False).map(lambda x: <unknown>)), text()), lambda strategy: st.lists(strategy, max_size=3), max_leaves=100)))'  # pylint: disable=C0301
     )
 
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -129,10 +129,11 @@ def test_generate_data_with_hypothesis(tmpdir):
     # assume the doubling experiment is at 100
     current_size = 100
     level = 1
+    position = [0]
     requested_types = ["hypothesis"]
     requested_oath = str(path)
     generated_data = generate.generate_data(
-        requested_types, current_size, level, requested_oath
+        requested_types, current_size, level, position, requested_oath
     )
     assert generated_data is not None
 

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -224,6 +224,36 @@ allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
     )
 
 
+def test_detect_level_and_position(tmpdir):
+    """Checks that generate strategy works for multiple level"""
+    path = tmpdir.mkdir('sub').join('hello.txt')
+    path.write(
+        '[{"type": "array", "items": [{"type": "number"}, {"type": "number"}]}\n\
+        ,{"type": "array", "items": [{"type": "number"}, {"type": "number"}]}]'
+    )
+    size = '50'
+    level = 2
+    position = [0, 0]
+    strategy = generate.generate_experiment_strategy(path, size, level,
+                                                     position)
+    assert (
+        str(strategy)
+        == '[builds(<function _operator.add>, tuples(floats(min_value=50.0, \
+max_value=50.0, allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>), floats(allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>)).map(list), \
+lists(recursive(one_of(one_of(one_of(one_of(none(), booleans()), integers()), \
+floats(allow_infinity=False, allow_nan=False).map(lambda x: <unknown>)), \
+text()), lambda strategy: st.lists(strategy, max_size=3), max_leaves=100))), \
+builds(<function _operator.add>, tuples(floats(allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>), floats(allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>)).map(list), \
+lists(recursive(one_of(one_of(one_of(one_of(none(), booleans()), integers()), \
+floats(allow_infinity=False, allow_nan=False).map(lambda x: <unknown>)), \
+text()), lambda strategy: st.lists(strategy, max_size=3), max_leaves=100)))]'
+    )
+
+
 def test_generate_func_from_single_st():
     """Checks that generate function from single strategy works"""
     # pylint: disable=blacklisted-name

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -203,6 +203,28 @@ allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
     )
 
 
+def test_generate_strategy_multiple_json_2(tmpdir):
+    """Checks that generate strategy works for two json objects in file"""
+    path = tmpdir.mkdir("sub").join("hello.txt")
+    path.write(
+        '[{"type": "array", "items": {"type": "number"}}\n\
+        ,{"type": "array", "items": {"type": "number"}}]'
+    )
+    size = "50"
+    strategy = generate.generate_experiment_strategy(path, size)
+    assert (
+        str(strategy[1])
+        != "lists(floats(allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
+    )
+    assert (
+        str(strategy[0])
+        == "lists(floats(allow_infinity=False, \
+allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
+    )
+
+
+
 def test_generate_func_from_single_st():
     """Checks that generate function from single strategy works"""
     # pylint: disable=blacklisted-name

--- a/tests/test_generate.py
+++ b/tests/test_generate.py
@@ -198,7 +198,7 @@ allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
     )
     assert (
         str(strategy[1])
-        == "lists(floats(allow_infinity=False, \
+        != "lists(floats(allow_infinity=False, \
 allow_nan=False).filter(lambda n: <unknown>), max_size=50, min_size=50)"
     )
 


### PR DESCRIPTION
- Changed the original level doubling detection to the recursive approach
- Added new argument: `--position` followed by a list to set the position of doubling
- Default as `[0]`

Example: Given JSON schema 
```
[{
  "type": "array",
  "items": [{
    "type": "integer",
    "maximum": 0,
    "minimum": 0
    },
    {
    "type": "integer",
    "maximum": 0,
    "minimum": 0
    }],
  "maxItems": 0,
  "minItems": 0
},
{
  "type": "array",
  "items": [{
    "type": "integer",
    "maximum": 0,
    "minimum": 0
    },
    {
    "type": "integer",
    "maximum": 0,
    "minimum": 0
    }],
  "maxItems": 0,
  "minItems": 0
}]
```

We can double the second integer in the first array using `--position 0 1`, where the first value 0 refers to the variable position at the first level, 0 means we want to focus on the first array. (1 means the second array) The second value 1 refers to the variable position at the second level, 1 means we want to focus on the second integer. (0 means the first integer)